### PR TITLE
Add a first pass at a course overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,104 @@
-# Codess in the classroom attendee material
+# Codess In The Classroom
 
-Repository to store the specs and instructions to use in the classroom.
+Welcome! This repository contains the Codess In The Classroom course
+materials. From here you will be able to find (and contribute to!) the
+materials we use in our hands-on workshops.
 
-1. [Week 1](./week1-webclient.md)
+## Introduction
+
+The course is going to be structured as a series of workshops, during which
+you will learn about various technologies and practices used in modern
+software development.
+
+In each workshop, you and your peers will be the development team working on
+part of a web application for an animal shelter. You will learn about
+front-end web development, APIs, testing and continuous integration, as well
+as how to deploy web applications to the cloud, and how to collaborate in a
+modern software team.
+
+During the workshop, you will have access to a group of mentors who will be
+there to help supplement the course materials and answer any questions you
+may have.
+
+## Learning goals
+
+Our goal is to give you a chance to learn about modern software development
+practices, and especially to learn about how web applications are designed,
+built, tested, and deployed.
+
+Over the duration of the course, you will build all the important parts of a
+web application that allows users to find and adopt adorable furry
+companions. Each workshop will focus on a different part of the application,
+and will draw on a different set of skills.
+
+Below, you'll find out what to expect in each workshop.
+
+## Course outline
+
+### Workshop 1: Modern front-end web development
+
+In this workshop, we're going to build a frontend of a website for the pet
+adoption center. In doing this, you'll learn:
+
+- What is a single-page application (SPA)?
+- What is an API (application programming interface)?
+- How to talk to an API from a SPA built with React.
+- How to use GitHub to submit a pull request (PR).
+- How to use pull requests as part of a code review process.
+
+_If you're ready, go to the [course notes for Workshop 1](./week1-webclient.md)._
+
+### Workshop 2: APIs and back-end web development
+
+In the first workshop, you built a single-page application that talked to an
+API service that returned information about pets up for adoption. In this
+workshop, you're going to build the pet adoption API yourselves, and host it
+in the cloud. You'll learn:
+
+- How is an API application different from other web applications?
+- How to pick between different options for building and hosting web applications.
+- How to design and build an API for listing pets available for adoption.
+- How to host your API application in Azure.
+
+_The notes for Workshop 2 aren't quite ready yet. We'll add them here when
+they are._
+
+### Workshop 3: Automated testing, continuous integration, continuous deployment
+
+So far, you've built both a front-end and a back-end for the pet adoption
+center's website. In this workshop, we're going to look at how you can
+automatically test the changes you make to your software, and how you can
+integrate those tests into a pipeline to help you release software quickly
+and easily. We hope you'll learn:
+
+- How to run tests automatically after every change.
+- How to use tests to provide automatic code review.
+- How to automatically deploy changes to your code after they pass the tests.
+
+_The notes for Workshop 3 aren't quite ready yet. We'll add them here when
+they are._
+
+### Workshop 4: Logs, metrics, and observability
+
+You have now built, tested, and deployed a web application to the cloud! Now
+you want to know whether it's doing the right thing. In this workshop, we're
+going to look at how to use logs and metrics to understand what your
+application is really doing in production, and gain insight into whether your
+users are having the experience you want them to. By adding instrumentation
+to your own application, you'll learn:
+
+- What we mean when we say "observability."
+- What are the differences between logs, metrics, and traces?
+- How to log useful data from your application.
+- How to emit metrics from your application.
+- Limitations and challenges of monitoring applications in production.
+
+_The notes for Workshop 4 aren't quite ready yet. We'll add them here when
+they are._
+
+## Contributions
+
+All of our course notes are open-source, and we invite corrections and
+contributions and corrections from anyone. Find a typo? [Send us a pull
+request](pull/new). Want to contribute a new module? [Open an issue to
+discuss your idea](issues/new).


### PR DESCRIPTION
Adds a first-pass course overview in terms of four workshops, with clear learning goals for each one.

Things to note:

- from my perspective this is more an exercise in finding the right structure and tone than in finding exactly the right content
- I'm open to feedback on any aspect of this document

Questions for reviewers:

- Is the tone right? Too light? Too serious?
- Is the scope for each 2h workshop too much? (Clearly this is going to be hard to answer without more detail on each workshop, but the important question is: will it be possible to design _some_ course materials that address the listed learning areas that fits into 2h?)

Thanks in advance!